### PR TITLE
chore: remove confirmation prompt from phoenix recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -139,7 +139,6 @@ nuke: clean-artifacts
 
 # Nuke everything and reinstall dependencies
 [group('maintenance')]
-[confirm("This will delete all dependencies and generated files, and reinstall them. Continue?")]
 [default]
 phoenix: nuke
     pnpm install


### PR DESCRIPTION
## Summary
- Removes the `[confirm(...)]` annotation from the `phoenix` just recipe so it runs without prompting for user confirmation

## Test plan
- [ ] Run `just phoenix` and verify it executes without a confirmation prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)