### PR TITLE
feat: add preview scripts for production build

### DIFF
--- a/apps/showcase/package.json
+++ b/apps/showcase/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "preview": "vite preview",
     "lint": "eslint . --fix",
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit",

--- a/justfile
+++ b/justfile
@@ -17,6 +17,11 @@ dev:
 build *filter:
     {{ if filter == "" { "pnpm build" } else { "pnpm build --filter " + filter } }}
 
+# Build and serve the production preview of apps/showcase
+[group('dev')]
+preview:
+    pnpm preview
+
 # Run linters across all packages
 [group('dev')]
 lint:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "turbo dev",
     "build": "turbo build",
+    "preview": "turbo preview",
     "lint": "turbo lint",
     "format": "turbo format",
     "format:check": "prettier --check .",

--- a/turbo.json
+++ b/turbo.json
@@ -20,6 +20,11 @@
       "persistent": true,
       "cache": false
     },
+    "preview": {
+      "dependsOn": ["build"],
+      "persistent": true,
+      "cache": false
+    },
     "typecheck": {
       "dependsOn": ["^build"]
     },


### PR DESCRIPTION
## Summary
- Add `preview` script to `apps/showcase` (`vite preview`)
- Add `preview` turbo task with `dependsOn: [build]`, `persistent: true`, `cache: false`
- Wire root `pnpm preview` and `just preview`

Adapted from #40 proposal (Next.js → Vite since repo uses `apps/showcase`). Serves on http://localhost:4173.

Closes #40.

## Test plan
- [x] `pnpm preview` returns 200
- [x] `just preview` returns 200
- [x] Build chain runs first via `dependsOn: [build]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)