### PR TITLE
chore: configure MCP servers and migrate to lefthook

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,14 @@
     "playwright": {
       "command": "npx",
       "args": ["@playwright/mcp@latest"]
+    },
+    "context7": {
+      "command": "npx",
+      "args": ["@context7/mcp@latest"]
+    },
+    "filesystem": {
+      "command": "npx",
+      "args": ["@modelcontextprotocol/server-filesystem@latest", "/Users/pauvelascogarrofe/Documents/base-monorepo-template"]
     }
   }
 }

--- a/.opencode/hooks
+++ b/.opencode/hooks
@@ -1,0 +1,1 @@
+.claude/hooks

--- a/.opencode/rules
+++ b/.opencode/rules
@@ -1,0 +1,1 @@
+../.agents/rules

--- a/.opencode/settings.json
+++ b/.opencode/settings.json
@@ -1,0 +1,1 @@
+.claude/settings.json

--- a/.opencode/settings.local.json
+++ b/.opencode/settings.local.json
@@ -1,0 +1,1 @@
+.claude/settings.local.json

--- a/.opencode/skills/shadcn
+++ b/.opencode/skills/shadcn
@@ -1,0 +1,1 @@
+../../.agents/skills/shadcn

--- a/.opencode/worktrees
+++ b/.opencode/worktrees
@@ -1,0 +1,1 @@
+.claude/worktrees

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ A monorepo GitHub template (`base-monorepo-template`) used as the starting point
 - rimraf 6.1.3 - Cross-platform file deletion utility
 - glob 13.0.6 - File pattern matching (used in tsup config)
 - globals 17.5.0 - Global object/variable definitions for linting
-- husky 9.1.7 - Git hooks manager
+- lefthook 2.1.6 - Git hooks manager
 - @commitlint/cli 20.5.0 - Commit message linting
 - @commitlint/config-conventional 20.5.0 - Conventional commits config
 ## Configuration

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,6 +1,8 @@
 pre-commit:
   parallel: true
   commands:
+    branch-check:
+      run: "[ \"$(git symbolic-ref --short HEAD)\" != \"main\" ] || (echo 'Direct commits to main branch are not allowed.' && exit 1)"
     typecheck:
       run: pnpm typecheck
     lint:

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "playwright": {
+      "type": "local",
+      "command": ["npx", "@playwright/mcp@latest"],
+      "enabled": true
+    },
+    "context7": {
+      "type": "remote",
+      "url": "https://mcp.context7.com/mcp",
+      "enabled": true
+    },
+    "filesystem": {
+      "type": "local",
+      "command": ["npx", "@modelcontextprotocol/server-filesystem@latest", "/Users/pauvelascogarrofe/Documents/base-monorepo-template"],
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add MCP (Model Context Protocol) server configurations for context7 and filesystem
- Migrate git hooks management from husky to lefthook
- Add branch protection to prevent accidental commits to main

## Testing
- Verify MCP servers load correctly
- Test that commits to main are blocked by lefthook pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)