### PR TITLE
docs: Add agent prompt templates

### DIFF
--- a/.agents/templates/bugfix-prompt.md
+++ b/.agents/templates/bugfix-prompt.md
@@ -1,0 +1,205 @@
+# Bugfix — Prompt Template
+
+> A fillable prompt for investigating and fixing a defect.
+> Use [`new-feature-prompt.md`](./new-feature-prompt.md) for new
+> functionality, [`refactor-prompt.md`](./refactor-prompt.md) for
+> behavior-preserving restructuring, or
+> [`new-project-prompt.md`](./new-project-prompt.md) for project
+> bootstrap.
+>
+> **How to use:**
+>
+> 1. Copy everything between `--- BEGIN PROMPT ---` and `--- END PROMPT ---`.
+> 2. Replace every `{{PLACEHOLDER}}`. Delete sections that don't apply.
+> 3. Paste into your agent of choice.
+>
+> The shape is biased toward **root-cause-first** debugging:
+> reproduce → diagnose → fix → regression-test → verify. The single
+> most common failure mode in agent-driven debugging is patching the
+> symptom; this template forces the agent to surface a hypothesis
+> before writing code.
+
+---
+
+--- BEGIN PROMPT ---
+
+## 1. Working Agreement
+
+You are my engineering partner on a bug investigation. Default
+behaviors:
+
+- **Reproduce before changing anything.** If you cannot reproduce, say
+  so and propose how to capture more evidence — do not start guessing.
+- **State a hypothesis before patching.** What's the root cause? Cite
+  the specific `file:line` you suspect. Wait for my agreement on the
+  hypothesis before writing the fix.
+- **Fix the cause, not the symptom.** No try/catch swallowing, no
+  defensive `if` checks that paper over an upstream invariant
+  violation, no `any` / `// @ts-ignore` / `eslint-disable` to silence
+  the compiler or linter.
+- **Add a failing test first when feasible** — one that captures the
+  bug. Make it pass with the fix. The test is the proof we shipped a
+  real fix.
+- **Read first.** Inspect `CLAUDE.md`, `AGENTS.md`,
+  `.agents/rules/*`, and the affected files before writing code.
+- **Match conventions already in the repo.**
+- **One logical commit per change.** Conventional Commits (`fix:` for
+  the fix, `test:` for the regression test if separated). Never
+  `--no-verify`.
+- **Ask one focused question on real ambiguity.** Don't invent
+  requirements.
+
+## 2. Bug Identity
+
+- **Title:** {{BUG_TITLE}}
+- **Tracking link:** {{ISSUE_OR_TICKET_URL_OR_NA}}
+- **Reported by:** {{NAME_OR_HANDLE}}
+- **Severity:** {{blocker | major | minor | trivial}}
+- **First seen:** {{DATE_OR_VERSION_OR_COMMIT_SHA}}
+- **Reproducibility:** {{always | intermittent — frequency | once}}
+
+## 3. Environment
+
+- **Affected workspace(s):** {{e.g. apps/web, packages/ui}}
+- **Branch / commit:** {{BRANCH_OR_SHA}}
+- **Runtime:** {{Node version, browser + version, OS, device}}
+- **Data state:** {{empty DB | seeded | production-like | NA}}
+- **Feature flags / env vars in play:** {{LIST | NA}}
+
+## 4. Reproduction Steps
+
+<!-- Be exact. The agent will follow these literally. -->
+
+1. {{STEP_1}}
+2. {{STEP_2}}
+3. {{STEP_3}}
+
+## 5. Expected vs. Actual
+
+- **Expected:** {{WHAT_SHOULD_HAPPEN}}
+- **Actual:** {{WHAT_HAPPENS_INSTEAD}}
+
+## 6. Evidence Already Gathered
+
+<!-- Paste relevant excerpts. Quote errors verbatim. -->
+
+- **Error message / stack trace:**
+
+  ```
+  {{PASTE_VERBATIM_OR_NA}}
+  ```
+
+- **Screenshots / videos:** {{LINK_OR_NA}}
+- **Recent commits suspected:** {{SHA — WHY_SUSPECTED | NA}}
+- **`git bisect` result:** {{FIRST_BAD_COMMIT | NOT_RUN}}
+- **Related logs / network calls:** {{PASTE_OR_LINK_OR_NA}}
+
+## 7. What I've Already Ruled Out
+
+<!--
+Saves the agent from re-walking dead-end paths. Be honest — if you
+haven't ruled anything out, write "nothing yet".
+-->
+
+- {{HYPOTHESIS_RULED_OUT_AND_WHY}}
+- {{HYPOTHESIS_RULED_OUT_AND_WHY}}
+
+## 8. Scope & Constraints
+
+- **Allowed blast radius:** {{e.g. "fix only — no refactors", "small refactor OK if it removes the cause"}}
+- **Files / areas off-limits:** {{LIST | NONE}}
+- **Backward compatibility:** {{must preserve API X | none required}}
+- **Performance regression budget:** {{e.g. no slowdown beyond 5%, NA}}
+- **Deadline:** {{DATE | none}}
+
+## 9. Definition of Done
+
+- [ ] Failing test added that reproduces the bug (pre-fix).
+- [ ] Test passes after the fix.
+- [ ] Existing test suite passes (`pnpm test`, `pnpm typecheck`,
+      `pnpm lint`, `pnpm e2e` if applicable).
+- [ ] Repro steps in §4 no longer trigger the bug.
+- [ ] Root cause documented in the commit message body.
+- [ ] {{ANY_PROJECT_SPECIFIC_GATE}}
+
+## 10. Risks & Open Questions
+
+- **Risks of this fix:**
+  - {{RISK_AND_MITIGATION}}
+- **Open questions (please surface answers or propose options):**
+  - {{QUESTION}}
+
+## 11. References
+
+- {{LINK_OR_PATH}} — {{WHAT_FOR}}
+- {{LINK_OR_PATH}} — {{WHAT_FOR}}
+
+## 12. GSD Workflow (Optional — skip if not using GSD)
+
+If this repo uses the GSD planning skill set:
+
+- **Standard bug (needs investigation):** `/gsd-debug` — runs the
+  scientific-method debug loop with persistent state across context
+  resets.
+- **Bug already diagnosed, fix is small (≤ 2 files):** `/gsd-quick`
+  or `/gsd-fast`.
+- **Bug surfaced during code review or audit:** `/gsd-audit-fix`
+  for autonomous audit-to-fix.
+- **Post-mortem on a previously failed workflow:** `/gsd-forensics`.
+
+Planning artifacts go under `.planning/<phase-name>/`. Do not edit
+`.planning/codebase/*.md` by hand.
+
+## 13. First Task
+
+<!--
+The single concrete thing to do RIGHT NOW. For bugs this is almost
+always: "reproduce, then state your root-cause hypothesis."
+-->
+
+Start by:
+
+{{FIRST_TASK_DESCRIPTION}}
+
+<!--
+Examples:
+  • "Reproduce the bug locally using §4. Then state your root-cause
+     hypothesis with file:line references. Wait for my agreement
+     before writing the fix."
+  • "Run /gsd-debug using the content above as input."
+  • "Add a failing Vitest test that captures the bug, then stop."
+-->
+
+## 14. Output Format Expectations
+
+- **Reproduction report:** "Reproduced ✅ / Not reproduced ❌" + the
+  exact command/steps you ran.
+- **Hypothesis:** one paragraph, with `file:line` citations and the
+  causal chain (X happens → triggers Y → which violates Z).
+- **For the fix:** show the diff; explain in one or two lines why this
+  fix addresses the cause, not just the symptom.
+- **For questions:** ask the smallest number that unblocks you
+  (ideally one).
+- **For status updates:** what changed, what's next, what's blocked —
+  three lines max.
+
+--- END PROMPT ---
+
+---
+
+## Appendix: Tips for filling this in
+
+- **§4 Reproduction is the highest-leverage section.** A vague repro
+  ("sometimes the page breaks") wastes more agent time than any other
+  gap. If you can't write exact steps, paste a screen recording link.
+- **§6 Quote errors verbatim.** Paraphrased errors strip the signal
+  (line numbers, stack frames, error codes) the agent needs.
+- **§7 Ruled-out hypotheses save more time than they look like they
+  do.** They prevent the agent from re-running the dead ends you
+  already tried.
+- **§8 Allowed blast radius matters.** Without it, agents either
+  refactor too much or refuse to touch surrounding code that's part
+  of the cause.
+- **§13 First Task should almost always be "reproduce + hypothesize"**
+  — not "write the fix". Letting the agent jump to a fix is the
+  fastest path to a symptom-patch.

--- a/.agents/templates/new-feature-prompt.md
+++ b/.agents/templates/new-feature-prompt.md
@@ -1,0 +1,204 @@
+# New Feature — Prompt Template
+
+> A fillable prompt for adding a feature to an **existing** project.
+> Use [`new-project-prompt.md`](./new-project-prompt.md) instead if
+> you're starting from scratch, [`bugfix-prompt.md`](./bugfix-prompt.md)
+> for defect work, or [`refactor-prompt.md`](./refactor-prompt.md) for
+> behavior-preserving restructuring.
+>
+> **How to use:**
+>
+> 1. Copy everything between `--- BEGIN PROMPT ---` and `--- END PROMPT ---`.
+> 2. Replace every `{{PLACEHOLDER}}`. Delete sections that don't apply.
+> 3. Paste into your agent of choice.
+>
+> The shape mirrors the project-bootstrap template but scoped down:
+> identity → why → outcomes → non-goals → acceptance → constraints →
+> working agreement → first task. Outcome-based framing and an explicit
+> non-goals list keep the agent inside the box you intend.
+
+---
+
+--- BEGIN PROMPT ---
+
+## 1. Working Agreement
+
+You are my engineering partner. For this feature:
+
+- **Read first.** Inspect `CLAUDE.md`, `AGENTS.md`, `.agents/rules/*`,
+  and the directory you'll be touching, before writing code.
+- **Match conventions already in the repo** — naming, file layout,
+  error handling, test style. Do not introduce new patterns unless
+  this prompt asks for them.
+- **Plan before writing code that touches more than ~3 files.** Surface
+  trade-offs and the option you'd pick. Wait for approval.
+- **One logical commit per change.** Conventional Commits. Never
+  `--no-verify`.
+- **Stop on failing tests, type errors, or lint errors.** Fix the cause;
+  don't suppress with `any`, `// @ts-ignore`, `eslint-disable`, or
+  skipped tests.
+- **Ask one focused question on real ambiguity.** Don't invent
+  requirements.
+
+## 2. Feature Identity
+
+- **Name:** {{FEATURE_NAME}}
+- **One-liner:** {{ONE_LINER}}
+  <!-- One sentence: what the feature does + for whom + the value. -->
+- **Tracking link:** {{ISSUE_OR_TICKET_URL_OR_NA}}
+- **Owner:** {{NAME_OR_HANDLE}}
+- **Target workspace(s):** {{e.g. apps/web, packages/ui}}
+
+## 3. Why This, Why Now
+
+- **User / business problem:** {{PROBLEM}}
+- **Evidence it matters:** {{DATA / FEEDBACK / SUPPORT_TICKETS / NA}}
+- **Trigger:** {{DEADLINE / BLOCKER / CUSTOMER_COMMITMENT / NA}}
+
+## 4. Users & Use Cases
+
+- **Primary user:** {{ROLE / PERSONA}}
+- **Top 1–3 use cases:**
+  1. {{USE_CASE_1}}
+  2. {{USE_CASE_2}}
+  3. {{USE_CASE_3}}
+
+## 5. Goals (Outcomes)
+
+<!-- Outcome-based, ordered by priority. 2–5 goals is healthy. -->
+
+1. {{OUTCOME_1}}
+2. {{OUTCOME_2}}
+3. {{OUTCOME_3}}
+
+## 6. Non-Goals
+
+<!-- The single sharpest tool for keeping scope honest. -->
+
+- {{NON_GOAL_1}}
+- {{NON_GOAL_2}}
+
+## 7. Acceptance Criteria
+
+<!--
+Concrete, testable. The agent will use these as the verification target.
+Prefer Given/When/Then or numbered checkboxes.
+-->
+
+- [ ] {{CRITERION_1}}
+- [ ] {{CRITERION_2}}
+- [ ] {{CRITERION_3}}
+
+## 8. Design & UX
+
+- **Mockups / specs:** {{LINK_OR_NA}}
+- **Existing components to reuse:** {{e.g. Button, Card from packages/ui}}
+- **New components needed:** {{NAME — PURPOSE | NA}}
+- **States to cover:** {{loading, empty, error, success, disabled, ...}}
+- **A11y requirements:** {{WCAG 2.2 AA | keyboard | screen reader | NA}}
+
+## 9. Data & APIs
+
+- **New data shapes:** {{TYPES_OR_SCHEMAS | NA}}
+- **APIs touched:** {{INTERNAL / EXTERNAL — endpoint + docs URL}}
+- **Auth / permissions:** {{WHO_CAN_DO_THIS | NA}}
+- **Migrations needed:** {{YES + WHAT | NO}}
+
+## 10. Constraints
+
+- **Performance:** {{e.g. interaction < 100ms, bundle delta < 10kb, NA}}
+- **Compatibility:** {{browsers, viewports, locales, devices}}
+- **Security / privacy:** {{PII handling, secrets, threat surface | NA}}
+- **Feature flags:** {{flag name + default | not behind a flag}}
+- **Rollout plan:** {{dark launch | gradual | full | NA}}
+
+## 11. Test Strategy
+
+- **Unit (Vitest):** {{what to cover}}
+- **Integration:** {{what to cover | NA}}
+- **E2E (Playwright):** {{user journeys to script | NA}}
+- **Visual / a11y:** {{tools and scope | NA}}
+- **Manual QA checklist:** {{steps the agent should hand back}}
+
+## 12. Out-of-Repo Touchpoints
+
+- **Docs to update:** {{README, CHANGELOG, design system docs, NA}}
+- **Other teams to notify:** {{NAMES / CHANNELS | NA}}
+- **Analytics events to add:** {{EVENT_NAME — PROPS | NA}}
+
+## 13. Risks & Open Questions
+
+- **Risks:**
+  - {{RISK_AND_MITIGATION}}
+- **Open questions (please surface answers or propose options):**
+  - {{QUESTION}}
+
+## 14. References
+
+- {{LINK_OR_PATH}} — {{WHAT_FOR}}
+- {{LINK_OR_PATH}} — {{WHAT_FOR}}
+
+## 15. GSD Workflow (Optional — skip if not using GSD)
+
+If this repo uses the GSD planning skill set, route as follows:
+
+- **Standard feature (≥ 1 hour, multi-file):**
+  `/gsd-spec-phase` → `/gsd-discuss-phase` → `/gsd-plan-phase` →
+  `/gsd-execute-phase` → `/gsd-verify-work` → `/gsd-ship`.
+- **Quick task (≤ 1 hour, low-risk, ≤ 2 files):** `/gsd-quick`.
+- **Trivial change (typo, copy fix, single-line tweak):** `/gsd-fast`.
+- **UI-heavy work:** start with `/gsd-ui-phase` to lock the design
+  contract before planning.
+- **AI / LLM integration:** start with `/gsd-ai-integration-phase`.
+
+Planning artifacts go under `.planning/<phase-name>/`. Do not edit
+`.planning/codebase/*.md` by hand — those come from
+`/gsd-map-codebase`.
+
+## 16. First Task
+
+<!--
+The single concrete thing to do RIGHT NOW after reading the prompt.
+Without this, agents either freeze or sprint in the wrong direction.
+-->
+
+Start by:
+
+{{FIRST_TASK_DESCRIPTION}}
+
+<!--
+Examples:
+  • "Read the prompt + relevant existing files, then propose 2 design
+     options as a numbered list with trade-offs. Wait for approval."
+  • "Run /gsd-spec-phase using the content above as input."
+  • "Scaffold a stub component at packages/ui/src/components/{{X}}.tsx
+     and a passing test, then stop."
+-->
+
+## 17. Output Format Expectations
+
+- **For plans / proposals:** numbered list, no fluff, surface trade-offs
+  and the option you'd pick.
+- **For code changes:** show the diff or full file content; cite
+  `file:line` for reference points.
+- **For questions:** ask the smallest number that unblocks you (ideally
+  one).
+- **For status updates:** what changed, what's next, what's blocked —
+  three lines max.
+
+--- END PROMPT ---
+
+---
+
+## Appendix: Tips for filling this in
+
+- **Outcomes > tasks in §5.** "User can drag-reorder a list and the
+  order persists across reload" beats "Add drag-and-drop".
+- **Non-goals are cheap and load-bearing.** One sharp non-goal saves
+  more agent tokens than three extra goals.
+- **§7 Acceptance criteria are the verification target.** If you
+  wouldn't accept the PR without it, write it down.
+- **§16 First Task is the most-skipped, highest-leverage section.**
+  Without it, agents freeze or sprint sideways.
+- **Delete sections that don't apply.** Empty sections still cost
+  context tokens.

--- a/.agents/templates/new-project-prompt.md
+++ b/.agents/templates/new-project-prompt.md
@@ -1,0 +1,323 @@
+# New Project Briefing — Prompt Template
+
+> A fillable prompt you paste into any AI coding agent (Claude Code, Cursor,
+> Aider, Cline, Codex, etc.) when you start a new project from this monorepo
+> template. Replace every `{{PLACEHOLDER}}` with concrete content. Delete
+> sections that don't apply. Keep the structure — agents perform best when
+> context is layered in a predictable order.
+>
+> **How to use:**
+>
+> 1. Fork this template repo into a new repository.
+> 2. Open the new repo in your agent of choice.
+> 3. Copy the prompt below (everything between the `--- BEGIN PROMPT ---`
+>    and `--- END PROMPT ---` markers), fill it in, and submit.
+> 4. The agent will read this prompt, the existing `CLAUDE.md` /
+>    `AGENTS.md`, and `.agents/rules/*` and start scaffolding.
+>
+> **Why this shape?** It mirrors Anthropic's 10-module prompt pattern
+> (task context → tone → background → rules → examples → history →
+> request → thinking → format → prefill) compressed into the order an
+> agent actually needs when bootstrapping a project: identity first,
+> intent second, constraints third, working agreement last. Outcome-based
+> framing (what "done" looks like) beats step-by-step instructions for
+> autonomous work.
+
+---
+
+--- BEGIN PROMPT ---
+
+## 1. Role & Working Agreement
+
+You are my engineering partner on this project. Default behaviors:
+
+- **Plan before large changes.** Surface assumptions and trade-offs before
+  writing code that touches more than ~3 files.
+- **Read before writing.** Inspect `CLAUDE.md`, `AGENTS.md`,
+  `.agents/rules/*`, `package.json`, `turbo.json`, and any `.planning/`
+  directory before proposing structure.
+- **Match existing conventions.** Naming, formatting, error handling,
+  module layout — copy the patterns already in the repo unless I ask
+  otherwise.
+- **Ask, don't guess, on ambiguity.** If a requirement below is unclear
+  or two interpretations are equally valid, ask one focused question
+  rather than picking silently.
+- **Show work in small commits.** One logical change per commit.
+  Conventional Commits format. Never `--no-verify`.
+- **Stop on failing tests, type errors, or lint errors.** Don't paper
+  over them with `any`, `// @ts-ignore`, `eslint-disable`, or skipped
+  tests.
+
+Communicate concisely. Skip filler. Use `file_path:line_number` when
+referencing code.
+
+## 2. Project Identity
+
+- **Name:** {{PROJECT_NAME}}
+- **One-liner:** {{ONE_LINER}}
+  <!-- One sentence: what it is + for whom + the value it delivers. -->
+- **Project type:** {{web-app | mobile-app | CLI | library | service | monorepo | other}}
+- **Stage:** {{greenfield | rewrite | extension-of-existing}}
+- **Repo URL:** {{REPO_URL}}
+- **Primary maintainer:** {{NAME / EMAIL / HANDLE}}
+
+## 3. Background & Problem
+
+<!--
+Why does this project exist? What is the user pain or business need?
+What was tried before, and why wasn't it enough? Keep it to a paragraph
+or two — agents do not need a wiki.
+-->
+
+- **Problem:** {{PROBLEM_STATEMENT}}
+- **Current state / status quo:** {{HOW_IT_WORKS_TODAY_OR_NA}}
+- **Why now:** {{TRIGGER_OR_DEADLINE}}
+
+## 4. Target Users & Stakeholders
+
+- **Primary users:** {{ROLE / PERSONA}} — {{WHAT_THEY_DO_WITH_IT}}
+- **Secondary users:** {{ROLE / PERSONA}} — {{WHAT_THEY_DO_WITH_IT}}
+- **Stakeholders / approvers:** {{TEAMS_OR_PEOPLE_WHOSE_SIGNOFF_MATTERS}}
+- **Estimated scale:** {{users / requests-per-day / data-volume / NA}}
+
+## 5. Goals (Outcomes)
+
+<!--
+Outcome-based, not task-based. "Users can X in under Y seconds" beats
+"Build a search bar". Order by priority. 3–7 goals is healthy.
+-->
+
+1. {{OUTCOME_1}}
+2. {{OUTCOME_2}}
+3. {{OUTCOME_3}}
+
+## 6. Non-Goals
+
+<!--
+The single highest-leverage section for keeping an agent on rails.
+Be aggressive: list things that look in-scope but aren't.
+-->
+
+- {{NON_GOAL_1}}
+- {{NON_GOAL_2}}
+
+## 7. Scope
+
+- **In scope:** {{FEATURES_OR_AREAS_INCLUDED}}
+- **Out of scope:** {{FEATURES_OR_AREAS_EXCLUDED}}
+- **Future / maybe-later:** {{IDEAS_PARKED_FOR_NEXT_MILESTONE}}
+
+## 8. Success Criteria / Definition of Done
+
+<!--
+How will we know this project shipped successfully? Mix qualitative and
+quantitative. The agent will use these as the verification target.
+-->
+
+- [ ] {{MEASURABLE_CRITERION_1}}
+- [ ] {{MEASURABLE_CRITERION_2}}
+- [ ] {{MEASURABLE_CRITERION_3}}
+
+## 9. Tech Stack
+
+This project starts from the `base-monorepo-template`. The baseline
+stack is already wired up — do not replace pieces unless this section
+explicitly says so.
+
+**Inherited (do not change without asking):**
+
+- TypeScript (strict, `noUncheckedIndexedAccess`)
+- Node.js 24+, pnpm 10
+- Turborepo for task orchestration
+- React 19, Vite 8, Tailwind CSS 4, Base UI React, shadcn
+- ESLint 10 (flat config) + Prettier (no semicolons, 120 cols)
+- Vitest (unit) + Playwright (E2E)
+- lefthook + commitlint (Conventional Commits)
+
+**Project-specific additions:**
+
+- {{LIBRARY}} — {{WHY_NEEDED}}
+- {{LIBRARY}} — {{WHY_NEEDED}}
+
+**Project-specific replacements (require justification):**
+
+- {{REPLACED_PIECE}} → {{NEW_CHOICE}} — {{REASON}}
+
+## 10. Architecture Direction
+
+<!--
+Just enough for the agent to make consistent choices. If you don't have
+opinions yet, write "TBD — propose options first".
+-->
+
+- **Workspaces planned:** {{e.g. apps/web, apps/api, packages/ui, packages/db}}
+- **Data flow:** {{client-only | client+API | event-driven | other}}
+- **Persistence:** {{none | localStorage | Postgres+Drizzle | Supabase | other}}
+- **Auth:** {{none | Clerk | Auth.js | custom | other}}
+- **Deployment target:** {{Vercel | Cloudflare | self-hosted | static | other}}
+- **Diagram / ADRs:** {{LINK_OR_NA}}
+
+## 11. Domain Model & Key Concepts
+
+<!--
+Glossary. Names matter — agents will pick them up and use them
+everywhere. Define the 5–10 nouns/verbs the codebase will live around.
+-->
+
+- **{{TERM}}** — {{DEFINITION}}
+- **{{TERM}}** — {{DEFINITION}}
+
+## 12. Constraints
+
+- **Performance:** {{e.g. LCP < 2s on 4G, p95 API latency < 200ms, NA}}
+- **Compatibility:** {{browsers, devices, Node versions, accessibility levels}}
+- **Compliance / privacy:** {{GDPR | HIPAA | SOC2 | none}}
+- **Security:** {{auth model, secret handling, threat surface notes}}
+- **Budget:** {{infra cost ceiling, paid-API ceiling, NA}}
+- **Timeline:** {{milestones / deadlines / "no deadline"}}
+- **Team / capacity:** {{solo | N engineers | + designer | + PM}}
+
+## 13. Quality Bars
+
+- **Test coverage:** {{target %, or "all critical paths"}}
+- **Test types required:** {{unit | integration | E2E | visual | a11y}}
+- **Accessibility:** {{WCAG 2.2 AA | other | NA}}
+- **Observability:** {{logging | tracing | error reporting (e.g. Sentry) | NA}}
+- **Documentation:** {{README only | full docs site | Storybook | NA}}
+- **Performance budget enforced in CI:** {{yes/no — what tool}}
+
+## 14. Conventions (Inherited)
+
+The agent must already follow:
+
+- `CLAUDE.md` (and `AGENTS.md` symlink) at repo root — project-wide
+  guidance.
+- `.agents/rules/typescript.md` — TS conventions (interface extends over
+  `&`, discriminated unions, no enums, `import type`, no default
+  exports, etc.).
+- `.prettierrc` — formatter config.
+- `eslint.config.ts` files in each workspace.
+
+**Project-specific conventions to add (if any):**
+
+- {{CONVENTION_1}}
+- {{CONVENTION_2}}
+
+## 15. External Integrations
+
+<!--
+APIs, SDKs, third-party services the project must talk to. Include the
+docs URL — agents browse better than they remember.
+-->
+
+| Service        | Purpose          | Docs URL          | Auth method          |
+| -------------- | ---------------- | ----------------- | -------------------- |
+| {{SERVICE}}    | {{WHAT_FOR}}     | {{DOCS_URL}}      | {{API_KEY / OAuth}}  |
+
+## 16. Deliverables & Milestones
+
+<!--
+What the agent should produce, in order. Even rough phases help —
+agents plan better when they see the arc, not just the next step.
+-->
+
+1. **{{MILESTONE_1}}** — {{OUTCOME}}
+2. **{{MILESTONE_2}}** — {{OUTCOME}}
+3. **{{MILESTONE_3}}** — {{OUTCOME}}
+
+## 17. Risks & Open Questions
+
+- **Risks:**
+  - {{RISK_AND_MITIGATION}}
+- **Open questions (please surface answers or propose options):**
+  - {{QUESTION}}
+  - {{QUESTION}}
+
+## 18. References & Inspiration
+
+<!--
+Links, screenshots, design files, competitor products, prior art.
+Agents use these for tone, style, and capability reference.
+-->
+
+- {{LINK_OR_PATH}} — {{WHAT_FOR}}
+- {{LINK_OR_PATH}} — {{WHAT_FOR}}
+
+## 19. GSD Workflow (Optional — skip if you're not using GSD)
+
+This template ships with the GSD planning skill set. If you want to use
+it, follow this routing:
+
+- **Brand new project:** run `/gsd-new-project` first. It uses the
+  contents of this prompt to produce `PROJECT.md`, then `ROADMAP.md`
+  with phases, then per-phase `SPEC.md` / `PLAN.md`.
+- **New milestone on an existing project:** run `/gsd-new-milestone`.
+- **Single phase / feature:** `/gsd-spec-phase` →
+  `/gsd-discuss-phase` → `/gsd-plan-phase` → `/gsd-execute-phase`
+  → `/gsd-verify-work`.
+- **Quick task (≤ 1 hour, low-risk):** `/gsd-quick`.
+- **Bug investigation:** `/gsd-debug`.
+- **Code review on a PR:** `/gsd-code-review` or `/gsd-ship`.
+
+Planning artifacts live under `.planning/`. Do not edit
+`.planning/codebase/*.md` by hand — those are produced by
+`/gsd-map-codebase`.
+
+If you are using a different agent system (vanilla Claude Code,
+Cursor, Aider, etc.), ignore this section and just work the
+deliverables list in §16.
+
+## 20. First Task
+
+<!--
+The single concrete thing the agent should do RIGHT NOW after reading
+the prompt. Without this, agents tend to either freeze or generate a
+plan you didn't ask for.
+-->
+
+Start by:
+
+{{FIRST_TASK_DESCRIPTION}}
+
+<!--
+Examples:
+  • "Read the entire prompt + CLAUDE.md, then propose a 3–5 phase
+     roadmap as a numbered list. Wait for my approval before writing
+     any code or planning files."
+  • "Run /gsd-new-project using the content above as input."
+  • "Scaffold the apps/api workspace using Hono + Drizzle, then stop."
+-->
+
+## 21. Output Format Expectations
+
+When you respond:
+
+- **For plans / proposals:** numbered list, no fluff, surface trade-offs
+  and the option you'd pick.
+- **For code changes:** show the diff or full file content; cite
+  `file:line` for reference points.
+- **For questions:** ask the smallest number that unblocks you (ideally
+  one).
+- **For status updates:** what changed, what's next, what's blocked —
+  three lines max.
+
+--- END PROMPT ---
+
+---
+
+## Appendix: Tips for filling this in
+
+- **Less is more for non-goals.** A sharp non-goal list saves more agent
+  tokens than any other section.
+- **Outcomes > tasks in §5.** "Users can sign in with Google in under
+  10 seconds" beats "Add a Google login button".
+- **§9 Tech Stack:** only list *additions* and *replacements* to the
+  monorepo baseline. The baseline is already documented in `CLAUDE.md`
+  and `.planning/codebase/STACK.md`; restating it wastes context.
+- **§19 First Task:** the most-skipped, highest-leverage section.
+  Without it, agents either freeze or sprint in the wrong direction.
+- **Keep it under ~600 lines once filled.** If a section keeps growing,
+  promote it to its own doc (`docs/architecture.md`,
+  `docs/domain-glossary.md`) and link from the prompt.
+- **Iterate.** Ship a v1, run a phase, then revise this prompt with the
+  surprises you learned. The prompt is a living artifact, not a spec.

--- a/.agents/templates/refactor-prompt.md
+++ b/.agents/templates/refactor-prompt.md
@@ -1,0 +1,288 @@
+# Refactor — Prompt Template
+
+> A fillable prompt for behavior-preserving code changes — restructuring,
+> renaming, extracting, deduplicating, modernizing, or migrating. Use
+> [`new-feature-prompt.md`](./new-feature-prompt.md) for new
+> functionality, [`bugfix-prompt.md`](./bugfix-prompt.md) for defects,
+> or [`new-project-prompt.md`](./new-project-prompt.md) for project
+> bootstrap.
+>
+> **How to use:**
+>
+> 1. Copy everything between `--- BEGIN PROMPT ---` and `--- END PROMPT ---`.
+> 2. Replace every `{{PLACEHOLDER}}`. Delete sections that don't apply.
+> 3. Paste into your agent of choice.
+>
+> The shape is biased toward **behavior preservation + scope discipline**:
+> characterize current behavior → propose strategy options → execute in
+> small reversible steps → prove parity. The two failure modes this
+> template guards against: (a) silent behavior drift, (b) scope creep
+> ("while I was in here…").
+
+---
+
+--- BEGIN PROMPT ---
+
+## 1. Working Agreement
+
+You are my engineering partner on a refactor. Default behaviors:
+
+- **Behavior preservation is the prime directive.** Unless §8 explicitly
+  authorizes a change, observable behavior — public API surface, return
+  types, error semantics, performance characteristics, side effects —
+  must be identical before and after.
+- **Characterize before you change.** Inspect existing tests. If
+  coverage on the target is thin, propose characterization tests
+  capturing current behavior *before* refactoring. Wait for approval.
+- **Propose strategy options before code.** For non-trivial refactors,
+  surface 2–3 approaches with trade-offs and the option you'd pick.
+  Wait for my agreement on the strategy before implementing.
+- **Small, reversible steps.** Each commit must leave the codebase in
+  a green state (tests + types + lint). Never bundle "phase 1" and
+  "phase 2" into one diff.
+- **No scope creep.** Out-of-scope cleanups go on a list at the end of
+  your response, not into the diff. Even if the cleanup is "right
+  next to" your change.
+- **Read first.** Inspect `CLAUDE.md`, `AGENTS.md`,
+  `.agents/rules/*`, and the affected files before writing code.
+- **Match conventions already in the repo** — naming, file layout,
+  error handling, test style. Refactors should *increase* convention
+  conformance, never decrease it.
+- **Conventional Commits.** `refactor:` for structure, `chore:` for
+  rename/move-only, `perf:` if behavior change is a deliberate
+  performance improvement (and only if §8 allows it). Never
+  `--no-verify`.
+- **Stop on failing tests, type errors, or lint errors.** Don't
+  suppress with `any`, `// @ts-ignore`, `eslint-disable`, or skipped
+  tests.
+- **Ask one focused question on real ambiguity.** Don't invent
+  requirements.
+
+## 2. Refactor Identity
+
+- **Title:** {{REFACTOR_TITLE}}
+- **One-liner:** {{ONE_LINER}}
+  <!-- One sentence: what changes structurally + what stays the same. -->
+- **Tracking link:** {{ISSUE_OR_TICKET_OR_NA}}
+- **Owner:** {{NAME_OR_HANDLE}}
+- **Refactor type:** {{rename | extract | inline | dedup | restructure | modernize | migrate | split | merge | other}}
+
+## 3. Target
+
+- **Files / directories in scope:** {{LIST}}
+- **Workspaces affected:** {{e.g. packages/ui, apps/showcase}}
+- **Public API surfaces touched:** {{NONE | LIST_OF_EXPORTS}}
+- **Approximate LOC affected:** {{ROUGH_COUNT}}
+
+## 4. Why Now (Cost Evidence)
+
+<!--
+Refactors without evidence of cost are vanity work. State the concrete
+pain. If you can't, reconsider whether to refactor at all.
+-->
+
+- **Current pain:** {{e.g. "duplicated 4 times across packages/ui",
+  "300-line component with nested conditionals", "uses deprecated
+  React API", "blocks upcoming feature X"}}
+- **Evidence:** {{LINK_TO_DUP / METRIC / RECENT_BUG_FROM_THIS_AREA}}
+- **Trigger:** {{UPCOMING_FEATURE | DEADLINE | TS_UPGRADE | NA}}
+
+## 5. Goals (Outcomes)
+
+<!--
+Outcome-based, ordered by priority. Examples: "single source of truth
+for X", "no file in this dir > 200 LOC", "type-safe at boundaries",
+"no deprecated APIs". 2–4 goals is healthy.
+-->
+
+1. {{OUTCOME_1}}
+2. {{OUTCOME_2}}
+3. {{OUTCOME_3}}
+
+## 6. Non-Goals
+
+<!--
+For refactors, the highest-leverage non-goal is usually "no behavior
+change". Be aggressive about parking adjacent improvements.
+-->
+
+- No behavior change beyond what §8 lists.
+- {{NON_GOAL_1}}
+- {{NON_GOAL_2}}
+
+## 7. Behavior Preservation Contract
+
+<!--
+The explicit list of what must NOT change. Skim against this before
+finalizing the diff.
+-->
+
+The following must remain identical:
+
+- [ ] Public exports (names, signatures, generic params, return types).
+- [ ] Runtime behavior for all current call sites.
+- [ ] Error messages, error types, and conditions under which errors
+      are thrown.
+- [ ] Side effects (network calls, storage writes, event emissions).
+- [ ] Performance characteristics (no O-class regressions).
+- [ ] {{PROJECT_SPECIFIC_INVARIANT}}
+
+## 8. Allowed Behavior Changes (if any)
+
+<!--
+Default: empty. If you genuinely intend a behavior change, list it
+explicitly here so the agent treats it as authorized rather than as
+a regression to flag.
+-->
+
+- {{ALLOWED_CHANGE_1 — WHY}} | NONE
+
+## 9. Strategy (Proposed or Open)
+
+<!--
+If you already know the approach, lock it. If not, ask the agent to
+propose options first.
+-->
+
+- **Proposed approach:** {{e.g. "extract shared logic into
+  packages/ui/src/hooks/use-x.ts, update 4 call sites in apps/showcase"}}
+- **Open for agent to propose:** {{YES | NO}}
+
+## 10. Test Parity Plan
+
+- **Existing test coverage on target:** {{HIGH | MEDIUM | LOW | NONE}}
+- **Characterization tests needed before refactor:** {{YES + WHAT | NO}}
+- **Tests to run for parity check:**
+  - `pnpm test` (Vitest)
+  - `pnpm typecheck`
+  - `pnpm lint`
+  - `pnpm e2e` (if applicable)
+  - {{ANY_PROJECT_SPECIFIC_GATE}}
+- **Snapshot / golden files affected:** {{LIST | NONE}}
+- **Manual smoke test (if any):** {{STEPS | NA}}
+
+## 11. Constraints
+
+- **Public API stability:** {{must preserve | breaking allowed but coordinated | NA}}
+- **Deprecation policy:** {{add `@deprecated` + keep N versions | hard remove | NA}}
+- **Bundle size delta budget:** {{e.g. ≤ +0kb, ≤ +5kb, NA}}
+- **Performance budget:** {{no regression | tolerated regression %, NA}}
+- **Backward compatibility window:** {{N versions | next major | none}}
+- **Files / areas off-limits:** {{LIST | NONE}}
+- **Deadline:** {{DATE | none}}
+
+## 12. Migration / Rollout
+
+- **Codemods needed:** {{YES + DESCRIPTION | NO}}
+- **Other repos / consumers affected:** {{LIST | NONE — internal only}}
+- **Communication needed:** {{CHANGELOG | release notes | team notify | NA}}
+- **Rollback plan:** {{git revert is safe | requires data fix | NA}}
+
+## 13. Definition of Done
+
+- [ ] All goals in §5 met.
+- [ ] All items in §7 verified unchanged.
+- [ ] All items in §8 (if any) implemented intentionally.
+- [ ] `pnpm test`, `pnpm typecheck`, `pnpm lint` green.
+- [ ] `pnpm e2e` green (if applicable).
+- [ ] No new ESLint disables, `any`, `// @ts-ignore`, or skipped tests.
+- [ ] Bundle size and performance within §11 budgets.
+- [ ] Out-of-scope improvements parked in a follow-up list, not
+      smuggled into the diff.
+- [ ] Commit history is reviewable: small, reversible steps.
+- [ ] {{ANY_PROJECT_SPECIFIC_GATE}}
+
+## 14. Risks & Open Questions
+
+- **Risks:**
+  - **Silent behavior drift** in {{AREA}} — mitigation: {{characterization
+    tests | manual smoke | type-level proof | other}}.
+  - {{RISK_AND_MITIGATION}}
+- **Open questions (please surface answers or propose options):**
+  - {{QUESTION}}
+
+## 15. References
+
+- {{LINK_OR_PATH}} — {{WHAT_FOR}}
+- {{LINK_OR_PATH}} — {{WHAT_FOR}}
+
+## 16. GSD Workflow (Optional — skip if not using GSD)
+
+If this repo uses the GSD planning skill set:
+
+- **Standard refactor (multi-file, needs strategy):**
+  `/gsd-spec-phase` → `/gsd-discuss-phase` → `/gsd-plan-phase` →
+  `/gsd-execute-phase` → `/gsd-verify-work` → `/gsd-ship`.
+- **Surgical refactor (1–2 files, mechanical):** `/gsd-quick`,
+  or delegate to the `cavecrew-builder` subagent for format-preserving
+  edits.
+- **Locating call sites first:** delegate to `cavecrew-investigator`
+  before planning.
+- **Code-quality-driven cleanup surfaced by audit:** `/gsd-audit-fix`.
+- **Convention compliance sweep (TS rules):** the `ts-reviewer`
+  subagent.
+
+Planning artifacts go under `.planning/<phase-name>/`. Do not edit
+`.planning/codebase/*.md` by hand.
+
+## 17. First Task
+
+<!--
+For refactors, the first task is almost always:
+  characterize current behavior + propose strategy options.
+Letting the agent jump straight to code is the fastest path to
+silent behavior drift.
+-->
+
+Start by:
+
+{{FIRST_TASK_DESCRIPTION}}
+
+<!--
+Examples:
+  • "Map every call site of {{TARGET}} (file:line table) and inspect
+     existing test coverage. Then propose 2–3 refactor strategies with
+     trade-offs and the one you'd pick. Wait for approval."
+  • "Run /gsd-spec-phase using the content above as input."
+  • "Add characterization tests covering current behavior of
+     {{TARGET}}, get them green, then stop."
+-->
+
+## 18. Output Format Expectations
+
+- **Mapping report:** `file:line` table of call sites and test
+  coverage status. No fluff.
+- **Strategy proposal:** numbered list of 2–3 options, each with: what
+  changes, what stays, blast radius, risks, the option you'd pick and
+  why.
+- **For code changes:** show the diff; cite `file:line` for context.
+  After each commit, restate behavior parity status (`tests green: ✅`,
+  `behavior identical: ✅` or call out what diverged and why).
+- **For questions:** ask the smallest number that unblocks you
+  (ideally one).
+- **Out-of-scope follow-ups:** dedicated list at the end of your
+  response, not in the diff.
+
+--- END PROMPT ---
+
+---
+
+## Appendix: Tips for filling this in
+
+- **§4 Cost evidence is mandatory.** Refactors without it become
+  vanity work. If you can't write a concrete pain, reconsider whether
+  this refactor should happen.
+- **§7 Behavior Preservation Contract is the strongest tool.** Reading
+  this list at the end of the diff catches drift faster than any test
+  suite.
+- **§8 Defaults to empty.** Filling it in deliberately converts a
+  refactor into a partial behavior change — that's fine, but it must
+  be explicit.
+- **§10 Characterization tests before refactor.** If coverage on the
+  target is thin, this is non-optional. The cost of writing them is
+  much smaller than the cost of a silent regression in production.
+- **§17 First Task = characterize + propose, not code.** Refactor
+  agents that skip straight to editing produce drift. Always.
+- **Out-of-scope follow-ups are a feature, not a chore.** Park them
+  visibly so they don't get lost — and don't smuggle them into the
+  current diff.

--- a/README.md
+++ b/README.md
@@ -44,3 +44,16 @@ pnpm build
 | `pnpm e2e`           | Run end-to-end tests (Playwright)  |
 | `pnpm test:coverage` | Run tests with coverage            |
 | `pnpm clean`         | Remove build artifacts             |
+
+## Agent prompt templates
+
+Fillable prompts for any AI coding agent (Claude Code, Cursor, Aider, Cline, Codex, etc.). Copy, fill in the `{{PLACEHOLDERS}}`, paste into your agent.
+
+| Template                                                                 | When to use                                              |
+| ------------------------------------------------------------------------ | -------------------------------------------------------- |
+| [`.agents/templates/new-project-prompt.md`](.agents/templates/new-project-prompt.md) | Bootstrapping a new project from this template           |
+| [`.agents/templates/new-feature-prompt.md`](.agents/templates/new-feature-prompt.md) | Adding a feature to an existing project                  |
+| [`.agents/templates/bugfix-prompt.md`](.agents/templates/bugfix-prompt.md)           | Investigating and fixing a bug                           |
+| [`.agents/templates/refactor-prompt.md`](.agents/templates/refactor-prompt.md)       | Behavior-preserving restructuring or modernization       |
+
+Project-wide rules and conventions live in [`CLAUDE.md`](CLAUDE.md) and [`.agents/rules/`](.agents/rules/).


### PR DESCRIPTION
## Summary

Add agent prompt templates to help developers bootstrap new projects, add features, fix bugs, and refactor code. These fillable templates work with any AI coding agent (Claude Code, Cursor, Aider, Cline, etc.).

## Changes

- Added `.agents/templates/` directory with prompt templates for common development tasks
- Updated README.md with table documenting each template and when to use it
- Links to CLAUDE.md and .agents/rules/ for project-wide conventions

## Testing

Documentation only — no code changes to verify.