### PR TITLE
chore(deps): migrate pnpm to v11.9.0

### DIFF
--- a/.agents/templates/new-project-prompt.md
+++ b/.agents/templates/new-project-prompt.md
@@ -127,7 +127,7 @@ explicitly says so.
 **Inherited (do not change without asking):**
 
 - TypeScript (strict, `noUncheckedIndexedAccess`)
-- Node.js 24+, pnpm 10
+- Node.js 24+, pnpm 11
 - Turborepo for task orchestration
 - React 19, Vite 8, Tailwind CSS 4, Base UI React, shadcn
 - ESLint 10 (flat config) + Prettier (no semicolons, 120 cols)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ packages/
 ## Prerequisites
 
 - Node.js >= 24
-- pnpm 10
+- pnpm 11
 
 ## Getting started
 

--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
     "typescript": "catalog:",
     "vitest": "catalog:"
   },
-  "packageManager": "pnpm@10.29.3"
+  "packageManager": "pnpm@11.9.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,11 @@ packages:
   - apps/*
   - packages/*
 
+allowBuilds:
+  esbuild: true
+  lefthook: true
+  msw: true
+
 catalog:
   '@testing-library/jest-dom': ^6.9.1
   '@testing-library/react': ^16.3.2
@@ -24,7 +29,5 @@ catalog:
   vitest: ^4.1.8
 
 dedupePeerDependents: true
-
-onlyBuiltDependencies: []
 
 preferFrozenLockfile: true


### PR DESCRIPTION
Bump `packageManager` to `pnpm@11.9.0` and replace `onlyBuiltDependencies` with the v11 `allowBuilds` map. Codemod (`pnpm-v10-to-v11`) applied.

### Changes
- `package.json`: `packageManager` 10.29.3 → 11.9.0
- `pnpm-workspace.yaml`: `onlyBuiltDependencies: []` removed; `allowBuilds: { esbuild, lefthook, msw }` added
- `README.md`: prerequisite 10 → 11
- `.agents/templates/new-project-prompt.md`: pnpm 10 → 11
- `pnpm-lock.yaml`: unchanged (v11 reads/writes v9.0 same format)

### v11 behavior notes
- Build scripts for esbuild, lefthook, msw now explicitly allowed. v11 fails installs when build scripts are ignored, unlike v10's warning.
- `managePackageManagerVersions` / `packageManagerStrict` / `COREPACK_ENABLE_STRICT` removed → replaced by `pmOnFail` (default `download`, matches previous default — no action needed).
- `useNodeVersion` → `devEngines.runtime`: not used.
- `auditConfig.ignoreCves` → `ignoreGhsas`: not used.
- No `.npmrc` in repo, no `pnpm` field in package.json — codemod was a no-op for those.

### Verified
- `pnpm install --frozen-lockfile` ✓
- `pnpm turbo build lint typecheck test` (11/11 tasks) ✓
- `pnpm format:check` ✓